### PR TITLE
FIX: Perbaikan gh action ansible

### DIFF
--- a/.github/workflows/deploy_opensid.yml
+++ b/.github/workflows/deploy_opensid.yml
@@ -2,7 +2,7 @@ name: Deploy OpenSID with Ansible
 
 on:
   release:
-    types: [published]
+    types: [published, edited, prereleased]
 
 permissions:
   contents: read
@@ -13,9 +13,13 @@ concurrency:
 
 jobs:
   deploy-production:
-    # Hanya jalan kalau rilis dari branch master & bukan prerelease
-    if: github.event.release.target_commitish == 'master' && github.event.release.prerelease == false
-    name: Deploy OpenSID to Production Server (Release)
+    # Hanya jalan kalau rilis dari branch master & bukan prerelease,
+    # serta event adalah published atau edited
+    if: |
+      github.event.release.target_commitish == 'master' &&
+      github.event.release.prerelease == false &&
+      (github.event.action == 'published' || github.event.action == 'edited')
+    name: Deploy OpenSID (Release)
     runs-on: ubuntu-latest
 
     steps:
@@ -35,9 +39,13 @@ jobs:
             ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opensid-rilis-premium.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"
 
   deploy-prerelease:
-    # Hanya jalan kalau rilis dari branch master & prerelease = true
-    if: github.event.release.target_commitish == 'master' && github.event.release.prerelease == true
-    name: Deploy OpenSID to Production Server (Pre-Release)
+    # Hanya jalan kalau rilis dari branch master & prerelease = true,
+    # serta event adalah published atau edited
+    if: |
+      github.event.release.target_commitish == 'master' &&
+      github.event.release.prerelease == true &&
+      (github.event.action == 'published' || github.event.action == 'edited')
+    name: Deploy OpenSID (Pre-Release)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_opensid_siappakai.yml
+++ b/.github/workflows/deploy_opensid_siappakai.yml
@@ -14,7 +14,10 @@ concurrency:
 jobs:
   deploy:
     # rilis dari branch 'master' & bukan prerelease
-    if: github.event.release.target_commitish == 'master' && github.event.release.prerelease == false
+    if: |
+      github.event.release.target_commitish == 'master' &&
+      github.event.release.prerelease == false &&
+      (github.event.action == 'published' || github.event.action == 'edited')
     name: Deploy SiapPakai Update OpenSID ke Server SiapPakai
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_opensid_siappakai.yml
+++ b/.github/workflows/deploy_opensid_siappakai.yml
@@ -2,7 +2,7 @@ name: Deploy SiapPakai Update OpenSID with Ansible
 
 on:
   release:
-    types: [published]
+    types: [published, edited, prereleased]
 
 permissions:
   contents: read
@@ -32,4 +32,5 @@ jobs:
           script: |
             set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-opensid.yml --vault-password-file ~/.vault_pass.txt
+            nohup ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-opensid.yml --vault-password-file ~/.vault_pass.txt > /tmp/ansible-siappakai-update-opensid.log 2>&1 &
+            echo "Ansible playbook started in background. Check /tmp/ansible-siappakai-update-opensid.log for output."

--- a/.github/workflows/deploy_rilis_beta.yml
+++ b/.github/workflows/deploy_rilis_beta.yml
@@ -2,11 +2,11 @@ name: Deploy Premium Rilis Beta with Ansible
 
 on:
   pull_request:
-    branches: [rilis-beta]
+    branches: [beta]
     types: [closed]
   push:
-    branches: [rilis-beta]
-    
+    branches: [beta]
+
 permissions:
   contents: read
 
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   deploy:
     if: github.event.pull_request.merged == true
-    name: Deploy Premium Rilis Beta to Production Server
+    name: Deploy Premium Rilis Beta
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Deskripsi
Setelah dicek dengan seksama, dengan konsep rilis tandai sebagai pra-rilis, edit rilis tandai sebagai rilis
Workflow sebelumnya hanya menjalankan job pra-rilis, sementara ketika pra-rilis tersebut diedit dan dijadikan latest rilis, job rilis tidak jalan

### Perubahan `deploy_opensid.yml`
- Perubahan menjadi seperti ini:
```
on:
  release:
    types: [published, edited, prereleased]
```

- Untuk deploy rilis filter seperti ini:
```
deploy-production:
    # Hanya jalan kalau rilis dari branch master & bukan prerelease,
    # serta event adalah published atau edited
    if: |
      github.event.release.target_commitish == 'master' &&
      github.event.release.prerelease == false &&
      (github.event.action == 'published' || github.event.action == 'edited')
```
- Untuk deploy pra-rilis filter seperti ini:
```
deploy-prerelease:
    # Hanya jalan kalau rilis dari branch master & prerelease = true,
    # serta event adalah published atau edited
    if: |
      github.event.release.target_commitish == 'master' &&
      github.event.release.prerelease == true &&
      (github.event.action == 'published' || github.event.action == 'edited')
```

### Perubahan `deploy_opensid_siappakai.yml`
- Perubahan menjadi seperti ini:
```
on:
  release:
    types: [published, edited, prereleased]
```

- Lalu ansible jalankan dibackground, karena prosesnya lama
```
nohup ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-opensid.yml --vault-password-file ~/.vault_pass.txt > /tmp/ansible-siappakai-update-opensid.log 2>&1 &
echo "Ansible playbook started in background. Check /tmp/ansible-siappakai-update-opensid.log for output."
```

### Perubahan `deploy_rilis_beta.yml`
- dari branch rilis-beta ke beta
```
on:
  pull_request:
    branches: [beta]
    types: [closed]
  push:
    branches: [beta]
```