### PR TITLE
feat: zap scan after release

### DIFF
--- a/.github/workflows/zap_scan_after_release.yml
+++ b/.github/workflows/zap_scan_after_release.yml
@@ -1,0 +1,85 @@
+name: ZAP Scan After Release Deployment
+
+on:
+  workflow_run:
+    workflows: ["Deploy OpenSID with Ansible"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Target URL to scan (optional, defaults to ZAP_TARGET_URL secret)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zap-scan-after-release
+  cancel-in-progress: false
+
+jobs:
+  zap-scan-production:
+    # Only run if:
+    # 1. Manual trigger (workflow_dispatch), OR
+    # 2. Deploy OpenSID workflow completed successfully
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    name: Run ZAP Security Scan on Production
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v4
+
+      - name: Set Release Information
+        id: release_info
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "tag_name=manual-trigger" >> $GITHUB_OUTPUT
+            echo "release_name=Manual Trigger" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          else
+            echo "tag_name=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+            echo "release_name=Deploy OpenSID Release ${{ github.event.workflow_run.name }}" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set Target URL
+        id: target_url
+        run: |
+          if [ -n "${{ github.event.inputs.target_url }}" ]; then
+            echo "url=${{ github.event.inputs.target_url }}" >> $GITHUB_OUTPUT
+          else
+            echo "url=${{ secrets.ZAP_TARGET_URL }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run ZAP Scan via Ansible
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_PORT }}
+          script: |
+            set -euo pipefail
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            
+            echo "🛡️ Starting OWASP ZAP Security Scan for Production Release"
+            echo "Release: ${{ steps.release_info.outputs.release_name }}"
+            echo "Target: ${{ steps.target_url.outputs.url }}"
+            
+            ansible-playbook -i inventories/production/inventory.yml playbooks/zap-scan.yml \
+              --extra-vars "zap_target_url=${{ steps.target_url.outputs.url }}"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### 🛡️ ZAP Security Scan Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release:** ${{ steps.release_info.outputs.release_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Target URL:** ${{ steps.target_url.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📊 Detailed reports have been sent to Telegram and are available on the Streamlit Dashboard." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## ZAP Scan After Release Deployment

### Apa yang dilakukan
Workflow ini menjalankan OWASP ZAP Security Scan untuk memindai keamanan aplikasi production setelah deployment berhasil.

### Kapan berjalan
1. **Otomatis**: Setiap kali workflow `Deploy OpenSID with Ansible` berhasil dijalankan tanpa error
2. **Manual**: Bisa dijalankan secara manual kapan saja melalui `workflow_dispatch` dengan optional input target URL

### Fitur
- 🛡️ Security scanning menggunakan OWASP ZAP
- 📊 Report dikirim ke Telegram dan tersedia di Streamlit Dashboard
- 🔧 Support manual trigger dengan custom target URL (atau gunakan default dari `ZAP_TARGET_URL` secret)
- ⚙️ Menggunakan Ansible untuk menjalankan scan di production server via SSH

## Referensi Issue:
- https://github.com/OpenSID/dasbor-siappakai/issues/792

## Referensi PR:
- https://github.com/OpenSID/Ansible/pull/12