### PR TITLE
refactor(deploy_opensid_siappakai.yml): deploy siappakai tengah malam

### DIFF
--- a/.github/workflows/deploy_opensid_siappakai.yml
+++ b/.github/workflows/deploy_opensid_siappakai.yml
@@ -39,11 +39,8 @@ jobs:
             echo "deploy=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Stop if no release to deploy
-        if: steps.pending.outputs.deploy != 'true'
-        run: exit 0
-
       - name: Deploy OpenSID ${{ steps.pending.outputs.tag }}
+        if: steps.pending.outputs.deploy == 'true'
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
@@ -57,6 +54,7 @@ jobs:
             echo "Ansible playbook started in background. Check /tmp/ansible-siappakai-update-opensid.log for output."
 
       - name: Clear pending release marker
+        if: steps.pending.outputs.deploy == 'true'
         run: |
           if [ -f .github/PENDING_RELEASE ]; then
             TAG=$(jq -r '.tag' .github/PENDING_RELEASE)

--- a/.github/workflows/deploy_opensid_siappakai.yml
+++ b/.github/workflows/deploy_opensid_siappakai.yml
@@ -1,11 +1,12 @@
 name: Deploy SiapPakai Update OpenSID with Ansible
 
 on:
-  release:
-    types: [published, edited, prereleased]
+  schedule:
+    - cron: '0 17 * * *' # 00:00 WIB
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: deploy-opensid-siappakai-rilis
@@ -13,19 +14,36 @@ concurrency:
 
 jobs:
   deploy:
-    # rilis dari branch 'master' & bukan prerelease
-    if: |
-      github.event.release.target_commitish == 'master' &&
-      github.event.release.prerelease == false &&
-      (github.event.action == 'published' || github.event.action == 'edited')
-    name: Deploy SiapPakai Update OpenSID ke Server SiapPakai
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Ansible Code
+      - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
-      - name: Deploy via SSH using appleboy/ssh-action
+      - name: Check for pending release
+        id: pending
+        run: |
+          if [ -f .github/PENDING_RELEASE ]; then
+            echo "Found pending release marker"
+            cat .github/PENDING_RELEASE
+            
+            TAG=$(jq -r '.tag' .github/PENDING_RELEASE)
+            
+            echo "deploy=true" >> $GITHUB_OUTPUT
+            echo "tag=${TAG}" >> $GITHUB_OUTPUT
+            echo "✅ Will deploy ${TAG}"
+          else
+            echo "No pending release found. Skipping deploy."
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Stop if no release to deploy
+        if: steps.pending.outputs.deploy != 'true'
+        run: exit 0
+
+      - name: Deploy OpenSID ${{ steps.pending.outputs.tag }}
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
@@ -37,3 +55,22 @@ jobs:
             cd ${{ secrets.CICD_SERVER_PATH }}
             nohup ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-opensid.yml --vault-password-file ~/.vault_pass.txt > /tmp/ansible-siappakai-update-opensid.log 2>&1 &
             echo "Ansible playbook started in background. Check /tmp/ansible-siappakai-update-opensid.log for output."
+
+      - name: Clear pending release marker
+        run: |
+          if [ -f .github/PENDING_RELEASE ]; then
+            TAG=$(jq -r '.tag' .github/PENDING_RELEASE)
+            BRANCH="${{ github.event.repository.default_branch }}"
+            
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            rm .github/PENDING_RELEASE
+            git add .github/PENDING_RELEASE
+            git commit -m "Clear release marker after deploying ${TAG}"
+            git push origin HEAD:${BRANCH}
+            
+            echo "✅ Pending release marker cleared"
+          else
+            echo "No marker file to clear"
+          fi

--- a/.github/workflows/deploy_opensid_siappakai.yml
+++ b/.github/workflows/deploy_opensid_siappakai.yml
@@ -63,8 +63,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             
-            rm .github/PENDING_RELEASE
-            git add .github/PENDING_RELEASE
+            git rm .github/PENDING_RELEASE
             git commit -m "Clear release marker after deploying ${TAG}"
             git push origin HEAD:${BRANCH}
             

--- a/.github/workflows/release_marker.yml
+++ b/.github/workflows/release_marker.yml
@@ -1,0 +1,58 @@
+name: Mark OpenSID Release for Midnight Deploy
+
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: write
+
+jobs:
+  mark-release:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Save release tag to marker file
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          PUBLISHED_AT="${{ github.event.release.published_at }}"
+          BRANCH="${{ github.event.release.target_commitish }}"
+          
+          echo "Marking release ${TAG} as pending deploy"
+          echo "Target branch: ${BRANCH}"
+          
+          # Create marker file
+          mkdir -p .github
+          cat > .github/PENDING_RELEASE << EOF
+          {
+            "tag": "${TAG}",
+            "published_at": "${PUBLISHED_AT}",
+            "marked_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          }
+          EOF
+          
+          echo "✅ Created marker for ${TAG}"
+          cat .github/PENDING_RELEASE
+
+      - name: Commit marker file
+        run: |
+          BRANCH="${{ github.event.release.target_commitish }}"
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git add .github/PENDING_RELEASE
+          
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Mark release ${{ github.event.release.tag_name }} for midnight deploy"
+            git push origin HEAD:${BRANCH}
+            echo "✅ Marker committed and pushed to ${BRANCH}"
+          fi


### PR DESCRIPTION
## Deskripsi
Saat ini, workflow deployment **SiapPakai ** berjalan langsung ketika tim OpenSID melakukan release di jam kerja, menyebabkan:

❌ Job Dasbor SiapPakai melakukan update di tengah jam kerja
❌ Downtime yang tidak terduga saat user sedang menggunakan aplikasi
❌ Komplain dari user karena gangguan layanan

### Solusi
Mengubah mekanisme deployment dari immediate trigger menjadi scheduled midnight deployment dengan pendekatan two-workflow pattern:

**release_marker.yml**
 - Menandai release baru tanpa deploy

**deploy_opensid_siappakai.ym**l
 - Deploy otomatis setiap jam 12 malam WIB


### Cara kerja
<img width="1024" height="1536" alt="ChatGPT Image 6 Feb 2026, 16 26 41" src="https://github.com/user-attachments/assets/4ed315ca-eccd-4f85-b693-a2d09f6a5b6f" />


### Perubahan
New File: `.github/workflows/release_marker.yml`

- Trigger saat OpenSID publish/edit release (non-prerelease)
- Membuat file marker .github/PENDING_RELEASE berisi info release
- Commit marker ke repository

Modified: `.github/workflows/deploy_opensid_siappakai.yml`

- ✅ Trigger berubah dari on: release → on: schedule (cron: 0 17 * * * = 00:00 WIB)
- ✅ Cek file .github/PENDING_RELEASE sebelum deploy
- ✅ Deploy hanya jika ada release pending
- ✅ Hapus marker setelah deploy berhasil
- ✅ Support manual trigger via workflow_dispatc

### Benefits

- ✅ No disruption during work hours - Deploy hanya jam 12 malam
- ✅ Automatic detection - Otomatis detect release baru dari OpenSID
- ✅ Safe & predictable - Deployment schedule yang konsisten
- ✅ Traceable - File marker visible di repository dengan git history
- ✅ Flexible - Tetap bisa manual trigger jika emergency

## Ceklis
- [x] Rilis tidak langsung menjalankan update
- [x]  Update hanya berjalan via schedule (cron)
- [x]  Waktu eksekusi sesuai WIB setelah konversi UTC
- [x]  Workflow dapat dijalankan manual bila diperlukan
- [x]  Tidak ada eksekusi update di luar jadwal

## Untuk issue
- https://github.com/OpenSID/DukunganTeknis/issues/1379

## Screenshot
- Github action berjalan (contoh)
<img width="1679" height="590" alt="image" src="https://github.com/user-attachments/assets/187fc2ad-8747-4286-837d-337fdd7df037" />

- Otomatis commit
<img width="1290" height="145" alt="image" src="https://github.com/user-attachments/assets/b4bddbf9-d203-4d5d-a98f-71ba3ee835de" />

- Commit buat file state
<img width="1889" height="524" alt="image" src="https://github.com/user-attachments/assets/115e4a81-8384-494f-96b7-f7acb9c8604b" />

- Commit hapus file state
<img width="1895" height="592" alt="image" src="https://github.com/user-attachments/assets/0527df2a-3432-402b-9232-cd680c7b5c95" />
